### PR TITLE
Add exitCode config option

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -286,9 +286,9 @@ export interface WebpackOptions {
 	 */
 	entry?: Entry;
 	/**
-	 * Exit code to use when handling SIGTERM.  NOTE: This option doesn't work when options is an array.
+	 * Exit code to use when handling SIGTERM.  NOTE: Only the first value is used when using multiple configurations.
 	 */
-	exitCode?: number;
+	exitCodeOnAbort?: number;
 	/**
 	 * Specify dependencies that shouldn't be resolved by webpack, but should become dependencies of the resulting bundle. The kind of the dependency depends on `output.libraryTarget`.
 	 */

--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -286,6 +286,10 @@ export interface WebpackOptions {
 	 */
 	entry?: Entry;
 	/**
+	 * Exit code to use when handling SIGTERM.  NOTE: This option doesn't work when options is an array.
+	 */
+	exitCode?: number;
+	/**
 	 * Specify dependencies that shouldn't be resolved by webpack, but should become dependencies of the resulting bundle. The kind of the dependency depends on `output.libraryTarget`.
 	 */
 	externals?: Externals;

--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -220,6 +220,7 @@ class SourceMapDevToolPlugin {
 						for (const file of chunk.files) {
 							if (
 								matchObject(file) &&
+								typeof sourceMapFilename === "string" &&
 								shouldGenerateSourceMapFile(
 									compilation,
 									options,

--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -35,6 +35,11 @@ const webpack = (options, callback) => {
 		compiler = new MultiCompiler(options.map(options => webpack(options)));
 	} else if (typeof options === "object") {
 		options = new WebpackOptionsDefaulter().process(options);
+		if (typeof options.exitCode === "number") {
+			process.on("SIGTERM", () => {
+				process.exit(options.exitCode);
+			});
+		}
 
 		compiler = new Compiler(options.context);
 		compiler.options = options;

--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -17,6 +17,8 @@ const version = require("../package.json").version;
 
 /** @typedef {import("../declarations/WebpackOptions").WebpackOptions} WebpackOptions */
 
+let sigtermHandler = null;
+
 /**
  * @param {WebpackOptions} options options object
  * @param {function(Error=, Stats=): void=} callback callback
@@ -35,10 +37,9 @@ const webpack = (options, callback) => {
 		compiler = new MultiCompiler(options.map(options => webpack(options)));
 	} else if (typeof options === "object") {
 		options = new WebpackOptionsDefaulter().process(options);
-		if (typeof options.exitCode === "number") {
-			process.on("SIGTERM", () => {
-				process.exit(options.exitCode);
-			});
+		if (typeof options.exitCodeOnAbort === "number" && !sigtermHandler) {
+			sigtermHandler = () => process.exit(options.exitCodeOnAbort);
+			process.on("SIGTERM", sigtermHandler);
 		}
 
 		compiler = new Compiler(options.context);

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -1954,8 +1954,8 @@
         }
       ]
     },
-    "exitCode": {
-      "description": "Exit code to use when handling SIGTERM.  NOTE: This option doesn't work when options is an array.",
+    "exitCodeOnAbort": {
+      "description": "Exit code to use when handling SIGTERM.  NOTE: Only the first value is used when using multiple configurations.",
       "type": "number"
     },
     "externals": {

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -1954,6 +1954,10 @@
         }
       ]
     },
+    "exitCode": {
+      "description": "Exit code to use when handling SIGTERM.  NOTE: This option doesn't work when options is an array.",
+      "type": "number"
+    },
     "externals": {
       "description": "Specify dependencies that shouldn't be resolved by webpack, but should become dependencies of the resulting bundle. The kind of the dependency depends on `output.libraryTarget`.",
       "anyOf": [

--- a/test/Validation.test.js
+++ b/test/Validation.test.js
@@ -197,7 +197,7 @@ describe("Validation", () => {
 			},
 			message: [
 				" - configuration has an unknown property 'postcss'. These properties are valid:",
-				"   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, externals?, loader?, mode?, module?, " +
+				"   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, exitCode?, externals?, loader?, mode?, module?, " +
 					"name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, " +
 					"recordsPath?, resolve?, resolveLoader?, serve?, stats?, target?, watch?, watchOptions? }",
 				"   For typos: please correct them.",

--- a/test/Validation.test.js
+++ b/test/Validation.test.js
@@ -197,7 +197,7 @@ describe("Validation", () => {
 			},
 			message: [
 				" - configuration has an unknown property 'postcss'. These properties are valid:",
-				"   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, exitCode?, externals?, loader?, mode?, module?, " +
+				"   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, exitCodeOnAbort?, externals?, loader?, mode?, module?, " +
 					"name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, " +
 					"recordsPath?, resolve?, resolveLoader?, serve?, stats?, target?, watch?, watchOptions? }",
 				"   For typos: please correct them.",


### PR DESCRIPTION
The `exitCode` option will allow us to control what the exit code is when webpack receives a `SIGTERM` (via `kill` or some other method).  This option doesn't work when the configuration is an array.  I tested these changes by making the same changes to `webpack` in `node_modules` in `webapp`.  I'll test again against this PR directly to double check that I've copied the changes correctly.

This PR also includes a fix for a typescript type error in `SourceMapDevToolPlugin.js`.